### PR TITLE
fix: create ReadinessStateDefinition before Etsy inventory updates

### DIFF
--- a/app/Services/Etsy/EtsyListingService.php
+++ b/app/Services/Etsy/EtsyListingService.php
@@ -43,25 +43,31 @@ class EtsyListingService
     public function createDraftListing(ListingDTO $listingDTO)
     {
         try {
+            $data = [
+                'title' => $listingDTO->title,
+                'description' => $listingDTO->description,
+                'quantity' => 999,
+                'price' => $listingDTO->price,
+                'who_made' => $listingDTO->whoMade,
+                'when_made' => $listingDTO->whenMade,
+                'taxonomy_id' => $listingDTO->taxonomyId,
+                'shipping_profile_id' => $listingDTO->shippingProfileId,
+                'return_policy_id' => $listingDTO->returnPolicyId,
+                'materials' => $listingDTO->materials,
+                'item_weight' => $listingDTO->itemWeight,
+                'item_length' => $listingDTO->itemLength,
+                'item_width' => $listingDTO->itemWidth,
+                'item_height' => $listingDTO->itemHeight,
+                'type' => 'physical',
+            ];
+
+            if (isset($this->shop->shop_oauth['readiness_state_definition_id'])) {
+                $data['readiness_state_id'] = $this->shop->shop_oauth['readiness_state_definition_id'];
+            }
+
             return Listing::create(
                 shop_id: $this->shop->shop_oauth['shop_id'],
-                data: [
-                    'title' => $listingDTO->title,
-                    'description' => $listingDTO->description,
-                    'quantity' => 999,
-                    'price' => $listingDTO->price,
-                    'who_made' => $listingDTO->whoMade,
-                    'when_made' => $listingDTO->whenMade,
-                    'taxonomy_id' => $listingDTO->taxonomyId,
-                    'shipping_profile_id' => $listingDTO->shippingProfileId,
-                    'return_policy_id' => $listingDTO->returnPolicyId,
-                    'materials' => $listingDTO->materials,
-                    'item_weight' => $listingDTO->itemWeight,
-                    'item_length' => $listingDTO->itemLength,
-                    'item_width' => $listingDTO->itemWidth,
-                    'item_height' => $listingDTO->itemHeight,
-                    'type' => 'physical',
-                ],
+                data: $data,
             );
         } catch (Exception $e) {
             Log::error($e->getMessage().PHP_EOL.$e->getFile().PHP_EOL.$e->getTraceAsString());

--- a/app/Services/Etsy/EtsyReadinessStateService.php
+++ b/app/Services/Etsy/EtsyReadinessStateService.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Services\Etsy;
+
+use App\Models\Shop;
+use Exception;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
+use Illuminate\Support\Facades\Log;
+
+class EtsyReadinessStateService
+{
+    protected Client $client;
+
+    public function __construct(
+        protected Shop $shop,
+    ) {
+        $this->client = new Client([
+            'base_uri' => 'https://openapi.etsy.com/v3/application/',
+            'headers' => [
+                'Authorization' => 'Bearer '.$this->shop->shop_oauth['access_token'],
+                'x-api-key' => $this->shop->shop_oauth['client_id'].':'.config('services.shops.etsy.client_secret'),
+                'Accept' => 'application/json',
+            ],
+        ]);
+    }
+
+    /**
+     * Creates a readiness state definition for the shop.
+     * If it already exists, retrieves the ID from the Conflict response.
+     *
+     * @return int|null The readiness state definition ID, or null on failure.
+     */
+    public function createReadinessStateDefinition(
+        string $readinessState = 'made_to_order',
+        int $minProcessingTime = 1,
+        int $maxProcessingTime = 10,
+        string $processingTimeUnit = 'days',
+    ): ?int {
+        $shopId = $this->shop->shop_oauth['shop_id'];
+
+        try {
+            $response = $this->client->post("shops/{$shopId}/readiness-state-definitions", [
+                'form_params' => [
+                    'readiness_state' => $readinessState,
+                    'min_processing_time' => $minProcessingTime,
+                    'max_processing_time' => $maxProcessingTime,
+                    'processing_time_unit' => $processingTimeUnit,
+                ],
+            ]);
+
+            $data = json_decode($response->getBody()->getContents(), true, 512, JSON_THROW_ON_ERROR);
+
+            return $data['readiness_state_definition_id'] ?? $data['id'] ?? null;
+        } catch (ClientException $e) {
+            if ($e->getResponse()->getStatusCode() === 409) {
+                // Definition already exists — retrieve ID from Content-Location header
+                $location = $e->getResponse()->getHeaderLine('Content-Location');
+                if ($location) {
+                    return $this->getReadinessStateDefinitionIdFromLocation($location);
+                }
+            }
+
+            Log::error($e->getMessage().PHP_EOL.$e->getFile().PHP_EOL.$e->getTraceAsString());
+
+            return null;
+        } catch (Exception $e) {
+            Log::error($e->getMessage().PHP_EOL.$e->getFile().PHP_EOL.$e->getTraceAsString());
+
+            return null;
+        }
+    }
+
+    private function getReadinessStateDefinitionIdFromLocation(string $location): ?int
+    {
+        try {
+            $response = $this->client->get($location);
+            $data = json_decode($response->getBody()->getContents(), true, 512, JSON_THROW_ON_ERROR);
+
+            return $data['readiness_state_definition_id'] ?? $data['id'] ?? null;
+        } catch (Exception $e) {
+            Log::error($e->getMessage().PHP_EOL.$e->getFile().PHP_EOL.$e->getTraceAsString());
+
+            return null;
+        }
+    }
+}

--- a/app/Services/Etsy/EtsyService.php
+++ b/app/Services/Etsy/EtsyService.php
@@ -275,6 +275,24 @@ class EtsyService
         return SellerTaxonomy::all();
     }
 
+    public function checkExistingReadinessStateDefinition(Shop $shop): void
+    {
+        if (isset($shop->shop_oauth['readiness_state_definition_id'])) {
+            return;
+        }
+
+        $this->refreshAccessToken($shop);
+
+        $definitionId = (new EtsyReadinessStateService(shop: $shop))->createReadinessStateDefinition();
+
+        if ($definitionId) {
+            $shopOauth = $shop->shop_oauth;
+            $shopOauth['readiness_state_definition_id'] = $definitionId;
+            $shop->shop_oauth = $shopOauth;
+            $shop->save();
+        }
+    }
+
     public function checkExistingShippingProfile(int $shopId, Shop $shop): void
     {
         $shippingProfileDTO = ShippingProfileDTO::fromShop($shopId);
@@ -522,6 +540,7 @@ class EtsyService
             shopId: $shop->shop_oauth['shop_id'],
             shop: $shop,
         );
+        $this->checkExistingReadinessStateDefinition($shop);
         $shop->refresh();
 
         $etsyListingService = new EtsyListingService(
@@ -581,6 +600,9 @@ class EtsyService
 
     private function updateListing(Shop $shop, Model $model): ListingDTO
     {
+        $this->checkExistingReadinessStateDefinition($shop);
+        $shop->refresh();
+
         $etsyListingService = new EtsyListingService(
             shop: $shop,
         );
@@ -615,6 +637,10 @@ class EtsyService
             'item_width' => $listingDTO->itemWidth,
             'item_height' => $listingDTO->itemHeight,
         ];
+
+        if (isset($shop->shop_oauth['readiness_state_definition_id'])) {
+            $data['readiness_state_id'] = $shop->shop_oauth['readiness_state_definition_id'];
+        }
 
         $etsyListingService->updateListing(
             listingId: $listing->listing_id,


### PR DESCRIPTION
Etsy requires a shop-level ReadinessStateDefinition before accepting inventory updates. Without it, the API returns "All offerings need readiness state" on PUT /inventory.

- Add EtsyReadinessStateService to create the definition via the API (handles 409 Conflict by reading ID from Content-Location header)
- Add checkExistingReadinessStateDefinition() in EtsyService, stores the returned ID in shop_oauth
- Call it in both createListing and updateListing before API calls
- Pass readiness_state_id in createDraftListing and updateListing data