### PR TITLE
fix: extract readiness state ID from URL and pass to inventory offerings

### DIFF
--- a/app/Services/Etsy/EtsyInventoryService.php
+++ b/app/Services/Etsy/EtsyInventoryService.php
@@ -39,11 +39,21 @@ class EtsyInventoryService
         }
     }
 
-    public function updateInventory(int $listingId, array $products)
+    public function updateInventory(int $listingId, array $products, ?int $readinessStateDefinitionId = null)
     {
         $inventoryProducts = [];
 
         foreach ($products as $product) {
+            $offering = [
+                'price' => (float) $product['price'],
+                'quantity' => $product['quantity'],
+                'is_enabled' => $product['is_enabled'],
+            ];
+
+            if ($readinessStateDefinitionId !== null) {
+                $offering['readiness_state_definition_id'] = $readinessStateDefinitionId;
+            }
+
             $inventoryProducts[] = [
                 'sku' => $product['sku'],
                 'property_values' => [
@@ -53,13 +63,7 @@ class EtsyInventoryService
                         'values' => [$product['material']],
                     ],
                 ],
-                'offerings' => [
-                    [
-                        'price' => (float) $product['price'],
-                        'quantity' => $product['quantity'],
-                        'is_enabled' => $product['is_enabled'],
-                    ],
-                ],
+                'offerings' => [$offering],
             ];
         }
 

--- a/app/Services/Etsy/EtsyReadinessStateService.php
+++ b/app/Services/Etsy/EtsyReadinessStateService.php
@@ -76,15 +76,16 @@ class EtsyReadinessStateService
 
     private function getReadinessStateDefinitionIdFromLocation(string $location): ?int
     {
-        try {
-            $response = $this->client->get($location);
-            $data = json_decode($response->getBody()->getContents(), true, 512, JSON_THROW_ON_ERROR);
+        // Extract ID directly from the URL path (last segment)
+        $id = (int) basename(parse_url($location, PHP_URL_PATH));
+        if ($id > 0) {
+            Log::info('Etsy readiness state definition ID extracted from location: '.$id);
 
-            return $data['readiness_state_definition_id'] ?? $data['id'] ?? null;
-        } catch (Exception $e) {
-            Log::error($e->getMessage().PHP_EOL.$e->getFile().PHP_EOL.$e->getTraceAsString());
-
-            return null;
+            return $id;
         }
+
+        Log::error('Could not extract readiness state definition ID from location: '.$location);
+
+        return null;
     }
 }

--- a/app/Services/Etsy/EtsyService.php
+++ b/app/Services/Etsy/EtsyService.php
@@ -707,11 +707,16 @@ class EtsyService
         }
 
         try {
+            $readinessStateDefinitionId = isset($shop->shop_oauth['readiness_state_definition_id'])
+                ? (int) $shop->shop_oauth['readiness_state_definition_id']
+                : null;
+
             $inventoryResponse = (new EtsyInventoryService(
                 shop: $shop,
             ))->updateInventory(
                 listingId: $listingId,
                 products: $variations,
+                readinessStateDefinitionId: $readinessStateDefinitionId,
             );
             Log::info('Listing inventory created: '.print_r($inventoryResponse, true));
         } catch (Exception $e) {


### PR DESCRIPTION
- Extract definition ID directly from Content-Location URL path (basename) instead of making a second GET request that was returning null
- Pass readiness_state_definition_id per offering in the inventory payload, which is what Etsy requires to satisfy "All offerings need readiness state"