### PR TITLE
fix: set readiness_state_id on listing before inventory update

### DIFF
--- a/app/Services/Etsy/EtsyInventoryService.php
+++ b/app/Services/Etsy/EtsyInventoryService.php
@@ -39,21 +39,11 @@ class EtsyInventoryService
         }
     }
 
-    public function updateInventory(int $listingId, array $products, ?int $readinessStateDefinitionId = null)
+    public function updateInventory(int $listingId, array $products)
     {
         $inventoryProducts = [];
 
         foreach ($products as $product) {
-            $offering = [
-                'price' => (float) $product['price'],
-                'quantity' => $product['quantity'],
-                'is_enabled' => $product['is_enabled'],
-            ];
-
-            if ($readinessStateDefinitionId !== null) {
-                $offering['readiness_state_definition_id'] = $readinessStateDefinitionId;
-            }
-
             $inventoryProducts[] = [
                 'sku' => $product['sku'],
                 'property_values' => [
@@ -63,7 +53,13 @@ class EtsyInventoryService
                         'values' => [$product['material']],
                     ],
                 ],
-                'offerings' => [$offering],
+                'offerings' => [
+                    [
+                        'price' => (float) $product['price'],
+                        'quantity' => $product['quantity'],
+                        'is_enabled' => $product['is_enabled'],
+                    ],
+                ],
             ];
         }
 

--- a/app/Services/Etsy/EtsyService.php
+++ b/app/Services/Etsy/EtsyService.php
@@ -619,10 +619,6 @@ class EtsyService
 
         Log::info('Update listing: '.$listingDTO->listingId);
 
-        // Update inventory with variations, first get existing inventory so we can keep the existing intact
-        $inventory = $this->getListingInventory($shop, $listingDTO->listingId);
-        $this->updateListingInventory($shop, $listingDTO, $inventory);
-
         $materials = [];
         if ($listingDTO->materials) {
             foreach ($listingDTO->materials as $material) {
@@ -630,7 +626,7 @@ class EtsyService
             }
         }
 
-        // Also set state to active again
+        // Update listing metadata first (including readiness_state_id) before inventory update
         $data = [
             'taxonomy_id' => $listingDTO->taxonomyId,
             'return_policy_id' => $listingDTO->returnPolicyId,
@@ -649,6 +645,10 @@ class EtsyService
             listingId: $listing->listing_id,
             data: $data,
         );
+
+        // Update inventory after listing has readiness_state_id set
+        $inventory = $this->getListingInventory($shop, $listingDTO->listingId);
+        $this->updateListingInventory($shop, $listingDTO, $inventory);
 
         (new ShopListingModelService)->updateShopListingModel($model->shopListingModel, $listingDTO);
 
@@ -707,16 +707,11 @@ class EtsyService
         }
 
         try {
-            $readinessStateDefinitionId = isset($shop->shop_oauth['readiness_state_definition_id'])
-                ? (int) $shop->shop_oauth['readiness_state_definition_id']
-                : null;
-
             $inventoryResponse = (new EtsyInventoryService(
                 shop: $shop,
             ))->updateInventory(
                 listingId: $listingId,
                 products: $variations,
-                readinessStateDefinitionId: $readinessStateDefinitionId,
             );
             Log::info('Listing inventory created: '.print_r($inventoryResponse, true));
         } catch (Exception $e) {


### PR DESCRIPTION
The readiness_state_id must be set on the listing itself first, then the inventory update will succeed. Moved listing update (with readiness_state_id) to before the inventory update call. Removed the invalid readiness_state_definition_id from the offerings payload.