### PR TITLE
fix: catch Shippo_InvalidRequestError in address validation and sanit…

### DIFF
--- a/app/Http/Controllers/Api/V1/AddressApiController.php
+++ b/app/Http/Controllers/Api/V1/AddressApiController.php
@@ -10,6 +10,8 @@ use App\Services\Admin\ShippingService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Log;
+use Shippo_InvalidRequestError;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 
@@ -17,13 +19,15 @@ class AddressApiController extends ApiController
 {
     public function validate(Request $request): JsonResponse
     {
+        $nullIfNullString = static fn (mixed $value): mixed => ($value === 'null' || $value === '') ? null : $value;
+
         $addressData = [
             'name' => $request->name,
-            'company' => $request->company ?? null,
+            'company' => $nullIfNullString($request->company),
             'street1' => $request->address_1,
-            'street2' => $request->address_2 ?? null,
+            'street2' => $nullIfNullString($request->address_2),
             'city' => $request->city,
-            'state' => $request->state ?? null,
+            'state' => $nullIfNullString($request->state),
             'zip' => $request->postal_code,
             'country' => $request->country,
             'email' => $request->email,
@@ -41,8 +45,22 @@ class AddressApiController extends ApiController
             return response()->json($response);
         }
 
-        $shippingService = app(ShippingService::class);
-        $response = $shippingService->setFromAddress($addressData)->validateAddress('From');
+        try {
+            $shippingService = app(ShippingService::class);
+            $response = $shippingService->setFromAddress($addressData)->validateAddress('From');
+        } catch (Shippo_InvalidRequestError $e) {
+            Log::warning('Shippo_InvalidRequestError during address validation', [
+                'address' => $addressData,
+                'error' => $e->getMessage(),
+            ]);
+            $response = [
+                'valid' => false,
+                'address' => $addressData,
+                'address_changed' => false,
+                'messages' => [['source' => 'SHIPPO', 'code' => 'invalid_request', 'type' => 'address_error', 'text' => $e->getMessage()]],
+            ];
+        }
+
         LogRequestService::addResponse($request, $response);
 
         return response()->json($response);


### PR DESCRIPTION
…ize null strings

- Sanitize state/company/street2 values of "null" (string) or "" to actual null before sending to Shippo — frontend sends state="null" for missing state fields
- Catch Shippo_InvalidRequestError (e.g. incomplete address) and return valid:false instead of letting it bubble up as an unhandled 500 error