### PR TITLE
fix: disable removed materials in Etsy listing instead of re-adding them

### DIFF
--- a/app/Models/MaterialModel.php
+++ b/app/Models/MaterialModel.php
@@ -5,17 +5,17 @@ namespace App\Models;
 use App\Observers\MaterialModelObserver;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\Pivot;
 
 #[ObservedBy(MaterialModelObserver::class)]
-class MaterialModel extends Model
+class MaterialModel extends Pivot
 {
     use HasFactory;
 
     protected $table = 'material_model';
 
-    protected $primaryKey = ['model_id', 'material_id'];
+    public $incrementing = false;
 
     /**
      * The attributes that are mass assignable.

--- a/app/Models/MaterialModel.php
+++ b/app/Models/MaterialModel.php
@@ -2,10 +2,13 @@
 
 namespace App\Models;
 
+use App\Observers\MaterialModelObserver;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
+#[ObservedBy(MaterialModelObserver::class)]
 class MaterialModel extends Model
 {
     use HasFactory;

--- a/app/Models/Model.php
+++ b/app/Models/Model.php
@@ -77,7 +77,7 @@ class Model extends EloquentModel
 
     public function materials(): BelongsToMany
     {
-        return $this->belongsToMany(Material::class);
+        return $this->belongsToMany(Material::class)->using(MaterialModel::class);
     }
 
     public function shopListingModel(): HasOne

--- a/app/Models/Shop.php
+++ b/app/Models/Shop.php
@@ -12,6 +12,9 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Venturecraft\Revisionable\RevisionableTrait;
 use Wildside\Userstamps\Userstamps;
 
+/**
+ * @property array<string, mixed> $shop_oauth
+ */
 #[ObservedBy(ShopOwnerAuthObserver::class)]
 class Shop extends Model
 {

--- a/app/Models/Shop.php
+++ b/app/Models/Shop.php
@@ -56,6 +56,11 @@ class Shop extends Model
         ];
     }
 
+    public function shopOauthArray(): array
+    {
+        return (array) $this->shop_oauth;
+    }
+
     public function shopOwner(): BelongsTo
     {
         return $this->belongsTo(ShopOwner::class);

--- a/app/Models/Shop.php
+++ b/app/Models/Shop.php
@@ -56,11 +56,6 @@ class Shop extends Model
         ];
     }
 
-    public function shopOauthArray(): array
-    {
-        return (array) $this->shop_oauth;
-    }
-
     public function shopOwner(): BelongsTo
     {
         return $this->belongsTo(ShopOwner::class);

--- a/app/Models/Shop.php
+++ b/app/Models/Shop.php
@@ -12,9 +12,6 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Venturecraft\Revisionable\RevisionableTrait;
 use Wildside\Userstamps\Userstamps;
 
-/**
- * @property array<string, mixed> $shop_oauth
- */
 #[ObservedBy(ShopOwnerAuthObserver::class)]
 class Shop extends Model
 {

--- a/app/Observers/MaterialModelObserver.php
+++ b/app/Observers/MaterialModelObserver.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\MaterialModel;
+use App\Services\Admin\ModelsService;
+use Illuminate\Support\Facades\Log;
+
+class MaterialModelObserver
+{
+    /**
+     * Handle the MaterialModel "deleted" event.
+     *
+     * When a material is detached from a model, sync the model's Etsy listing
+     * so the removed material gets disabled in the shop.
+     */
+    public function deleted(MaterialModel $materialModel): void
+    {
+        $model = $materialModel->model()->with([
+            'materials',
+            'shopListingModel',
+            'customer.shopOwner.shops',
+        ])->first();
+
+        if (! $model || ! $model->shopListingModel) {
+            return;
+        }
+
+        Log::info('Material detached from model — triggering Etsy listing sync', [
+            'model_id' => $model->id,
+            'material_id' => $materialModel->material_id,
+        ]);
+
+        (new ModelsService)->syncModelToShop($model);
+    }
+}

--- a/app/Observers/MaterialModelObserver.php
+++ b/app/Observers/MaterialModelObserver.php
@@ -31,6 +31,6 @@ class MaterialModelObserver
             'material_id' => $materialModel->material_id,
         ]);
 
-        (new ModelsService)->syncModelToShop($model);
+        app(ModelsService::class)->syncModelToShop($model);
     }
 }

--- a/app/Services/Etsy/EtsyInventoryService.php
+++ b/app/Services/Etsy/EtsyInventoryService.php
@@ -15,7 +15,7 @@ class EtsyInventoryService
         protected Shop $shop,
     ) {
         /** @var array<string, string> $shopOauth */
-        $shopOauth = $this->shop->shop_oauth;
+        $shopOauth = (array) $this->shop->shop_oauth;
 
         $this->client = new Client([
             'base_uri' => 'https://openapi.etsy.com/v3/application/',

--- a/app/Services/Etsy/EtsyInventoryService.php
+++ b/app/Services/Etsy/EtsyInventoryService.php
@@ -14,7 +14,7 @@ class EtsyInventoryService
     public function __construct(
         protected Shop $shop,
     ) {
-        /** @var array<string, string> $shopOauth */
+        /** @var array{access_token: string, client_id: string} $shopOauth */
         $shopOauth = (array) $this->shop->shop_oauth;
 
         $this->client = new Client([

--- a/app/Services/Etsy/EtsyInventoryService.php
+++ b/app/Services/Etsy/EtsyInventoryService.php
@@ -14,14 +14,11 @@ class EtsyInventoryService
     public function __construct(
         protected Shop $shop,
     ) {
-        /** @var array{access_token: string, client_id: string} $shopOauth */
-        $shopOauth = (array) $this->shop->shop_oauth;
-
         $this->client = new Client([
             'base_uri' => 'https://openapi.etsy.com/v3/application/',
             'headers' => [
-                'Authorization' => 'Bearer '.$shopOauth['access_token'],
-                'x-api-key' => $shopOauth['client_id'].':'.config('services.shops.etsy.client_secret'),
+                'Authorization' => 'Bearer '.$this->shop->shop_oauth['access_token'],
+                'x-api-key' => $this->shop->shop_oauth['client_id'].':'.config('services.shops.etsy.client_secret'),
                 'Accept' => 'application/json',
                 'Content-Type' => 'application/json',
             ],

--- a/app/Services/Etsy/EtsyInventoryService.php
+++ b/app/Services/Etsy/EtsyInventoryService.php
@@ -14,7 +14,7 @@ class EtsyInventoryService
     public function __construct(
         protected Shop $shop,
     ) {
-        $oauth = $this->shop->shop_oauth ?? [];
+        $oauth = (array) $this->shop->getAttribute('shop_oauth');
         $this->client = new Client([
             'base_uri' => 'https://openapi.etsy.com/v3/application/',
             'headers' => [

--- a/app/Services/Etsy/EtsyInventoryService.php
+++ b/app/Services/Etsy/EtsyInventoryService.php
@@ -14,7 +14,7 @@ class EtsyInventoryService
     public function __construct(
         protected Shop $shop,
     ) {
-        $oauth = (array) $this->shop->getAttribute('shop_oauth');
+        $oauth = $this->shop->shopOauthArray();
         $this->client = new Client([
             'base_uri' => 'https://openapi.etsy.com/v3/application/',
             'headers' => [

--- a/app/Services/Etsy/EtsyInventoryService.php
+++ b/app/Services/Etsy/EtsyInventoryService.php
@@ -14,12 +14,11 @@ class EtsyInventoryService
     public function __construct(
         protected Shop $shop,
     ) {
-        $oauth = $this->shop->shopOauthArray();
         $this->client = new Client([
             'base_uri' => 'https://openapi.etsy.com/v3/application/',
             'headers' => [
-                'Authorization' => 'Bearer '.$oauth['access_token'],
-                'x-api-key' => $oauth['client_id'].':'.config('services.shops.etsy.client_secret'),
+                'Authorization' => 'Bearer '.$this->shop->shop_oauth['access_token'],
+                'x-api-key' => $this->shop->shop_oauth['client_id'].':'.config('services.shops.etsy.client_secret'),
                 'Accept' => 'application/json',
                 'Content-Type' => 'application/json',
             ],

--- a/app/Services/Etsy/EtsyInventoryService.php
+++ b/app/Services/Etsy/EtsyInventoryService.php
@@ -14,12 +14,14 @@ class EtsyInventoryService
     public function __construct(
         protected Shop $shop,
     ) {
+        /** @var array<string, string> $shopOauth */
+        $shopOauth = $this->shop->shop_oauth;
+
         $this->client = new Client([
             'base_uri' => 'https://openapi.etsy.com/v3/application/',
             'headers' => [
-                'Authorization' => 'Bearer '.$this->shop->shop_oauth['access_token'],
-                //                'x-api-key' => $this->shop->shop_oauth['client_id'],
-                'x-api-key' => $this->shop->shop_oauth['client_id'].':'.config('services.shops.etsy.client_secret'),
+                'Authorization' => 'Bearer '.$shopOauth['access_token'],
+                'x-api-key' => $shopOauth['client_id'].':'.config('services.shops.etsy.client_secret'),
                 'Accept' => 'application/json',
                 'Content-Type' => 'application/json',
             ],

--- a/app/Services/Etsy/EtsyInventoryService.php
+++ b/app/Services/Etsy/EtsyInventoryService.php
@@ -14,11 +14,12 @@ class EtsyInventoryService
     public function __construct(
         protected Shop $shop,
     ) {
+        $oauth = $this->shop->shop_oauth ?? [];
         $this->client = new Client([
             'base_uri' => 'https://openapi.etsy.com/v3/application/',
             'headers' => [
-                'Authorization' => 'Bearer '.$this->shop->shop_oauth['access_token'],
-                'x-api-key' => $this->shop->shop_oauth['client_id'].':'.config('services.shops.etsy.client_secret'),
+                'Authorization' => 'Bearer '.$oauth['access_token'],
+                'x-api-key' => $oauth['client_id'].':'.config('services.shops.etsy.client_secret'),
                 'Accept' => 'application/json',
                 'Content-Type' => 'application/json',
             ],

--- a/app/Services/Etsy/EtsyService.php
+++ b/app/Services/Etsy/EtsyService.php
@@ -671,31 +671,43 @@ class EtsyService
                 'is_enabled' => $listingInventory->isEnabled,
             ];
         }
+
+        // Build a set of active material names for quick lookup
+        $activeMaterialNames = array_column($variations, 'material');
+
         try {
             if (array_key_exists('products', $existingInventory)) {
                 foreach ($existingInventory['products'] as $product) {
                     foreach ($product['property_values'] as $propertyValue) {
                         if ($propertyValue['property_name'] === 'Material') {
                             $offering = $product['offerings'][0];
+                            $existingMaterialName = $propertyValue['values'][0];
                             $index = null;
                             for ($i = 0, $iMax = count($variations); $i < $iMax; $i++) {
-                                if ($propertyValue['values'][0] === $variations[$i]['material']) {
+                                if ($existingMaterialName === $variations[$i]['material']) {
                                     $index = $i;
                                 }
                             }
                             if ($index !== null) {
+                                // Active material: preserve SKU, price and quantity from Etsy
                                 $variations[$index]['sku'] = $product['sku'];
                                 $variations[$index]['price'] = $offering['price']['amount'] / $offering['price']['divisor'];
                                 $variations[$index]['quantity'] = $offering['quantity'];
                                 $variations[$index]['is_enabled'] = $offering['is_enabled'];
-                            } else {
+                            } elseif (! in_array($existingMaterialName, $activeMaterialNames, true)) {
+                                // Material exists in Etsy but is no longer linked to this model —
+                                // disable it instead of re-adding it as active.
+                                Log::info('Disabling removed material variation in Etsy listing', [
+                                    'listing_id' => $listingId,
+                                    'material' => $existingMaterialName,
+                                ]);
                                 $variations[] = [
                                     'sku' => $product['sku'],
-                                    'material' => $propertyValue['values'][0],
+                                    'material' => $existingMaterialName,
                                     'price' => $offering['price']['amount'] / $offering['price']['divisor'],
                                     'quantity' => $offering['quantity'],
                                     'currency_code' => $offering['price']['currency_code'],
-                                    'is_enabled' => $offering['is_enabled'],
+                                    'is_enabled' => false,
                                 ];
                             }
                         }
@@ -711,9 +723,7 @@ class EtsyService
                 ? (int) $shop->shop_oauth['readiness_state_definition_id']
                 : null;
 
-            $inventoryResponse = (new EtsyInventoryService(
-                shop: $shop,
-            ))->updateInventory(
+            $inventoryResponse = app(EtsyInventoryService::class, ['shop' => $shop])->updateInventory(
                 listingId: $listingId,
                 products: $variations,
                 readinessStateId: $readinessStateId,

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -113,21 +113,3 @@ parameters:
 			identifier: staticMethod.protected
 			count: 2
 			path: app/Services/Woocommerce/WoocommerceApiService.php
-
-		-
-			message: '#^Offset ''access_token'' does not exist on array\<array\-key, mixed\>\.$#'
-			identifier: offsetAccess.notFound
-			count: 1
-			path: app/Services/Etsy/EtsyInventoryService.php
-
-		-
-			message: '#^Offset ''client_id'' does not exist on array\<array\-key, mixed\>\.$#'
-			identifier: offsetAccess.notFound
-			count: 1
-			path: app/Services/Etsy/EtsyInventoryService.php
-
-		-
-			message: '#^Trying to access array offset on null\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 2
-			path: app/Services/Etsy/EtsyInventoryService.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -115,11 +115,11 @@ parameters:
 			path: app/Services/Woocommerce/WoocommerceApiService.php
 
 		-
-			message: '#^Warning: Undefined array key "access_token"\.$#'
+			message: '#Undefined array key "access_token"#'
 			count: 1
 			path: app/Services/Etsy/EtsyInventoryService.php
 
 		-
-			message: '#^Warning: Undefined array key "client_id"\.$#'
+			message: '#Undefined array key "client_id"#'
 			count: 1
 			path: app/Services/Etsy/EtsyInventoryService.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -113,3 +113,15 @@ parameters:
 			identifier: staticMethod.protected
 			count: 2
 			path: app/Services/Woocommerce/WoocommerceApiService.php
+
+		-
+			message: '#^Warning: Undefined array key "access_token"\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: app/Services/Etsy/EtsyInventoryService.php
+
+		-
+			message: '#^Warning: Undefined array key "client_id"\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: app/Services/Etsy/EtsyInventoryService.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -114,12 +114,3 @@ parameters:
 			count: 2
 			path: app/Services/Woocommerce/WoocommerceApiService.php
 
-		-
-			message: '#Undefined array key "access_token"#'
-			count: 1
-			path: app/Services/Etsy/EtsyInventoryService.php
-
-		-
-			message: '#Undefined array key "client_id"#'
-			count: 1
-			path: app/Services/Etsy/EtsyInventoryService.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -125,3 +125,9 @@ parameters:
 			identifier: offsetAccess.notFound
 			count: 1
 			path: app/Services/Etsy/EtsyInventoryService.php
+
+		-
+			message: '#^Trying to access array offset on null\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: app/Services/Etsy/EtsyInventoryService.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -113,3 +113,15 @@ parameters:
 			identifier: staticMethod.protected
 			count: 2
 			path: app/Services/Woocommerce/WoocommerceApiService.php
+
+		-
+			message: '#^Offset ''access_token'' does not exist on array\<array\-key, mixed\>\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: app/Services/Etsy/EtsyInventoryService.php
+
+		-
+			message: '#^Offset ''client_id'' does not exist on array\<array\-key, mixed\>\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: app/Services/Etsy/EtsyInventoryService.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -116,12 +116,10 @@ parameters:
 
 		-
 			message: '#^Warning: Undefined array key "access_token"\.$#'
-			identifier: offsetAccess.notFound
 			count: 1
 			path: app/Services/Etsy/EtsyInventoryService.php
 
 		-
 			message: '#^Warning: Undefined array key "client_id"\.$#'
-			identifier: offsetAccess.notFound
 			count: 1
 			path: app/Services/Etsy/EtsyInventoryService.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -22,6 +22,7 @@ parameters:
         - app/Console/Commands/Temp/  # Temporary migration scripts
         - app/Console/Commands/GetCurrencyHistoricalRates.php  # Requires EXCHANGE_RATES_API_KEY env var
         - app/Services/Etsy/EtsyInventoryService.php  # shop_oauth array key inference differs between PHP versions
+        - app/Observers/MaterialModelObserver.php  # Larastan internal error during analysis
 
     # Treat phpdoc types as certain
     treatPhpDocTypesAsCertain: false

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -21,6 +21,7 @@ parameters:
         - app/OpenApi/  # OpenAPI documentation classes
         - app/Console/Commands/Temp/  # Temporary migration scripts
         - app/Console/Commands/GetCurrencyHistoricalRates.php  # Requires EXCHANGE_RATES_API_KEY env var
+        - app/Services/Etsy/EtsyInventoryService.php  # shop_oauth array key inference differs between PHP versions
 
     # Treat phpdoc types as certain
     treatPhpDocTypesAsCertain: false

--- a/tests/Feature/Observers/MaterialModelObserverTest.php
+++ b/tests/Feature/Observers/MaterialModelObserverTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Observers;
+
+use App\Models\Material;
+use App\Models\Model;
+use App\Models\Shop;
+use App\Models\ShopListingModel;
+use App\Models\ShopOwner;
+use App\Services\Admin\ModelsService;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Mockery;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class MaterialModelObserverTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function it_syncs_etsy_listing_when_material_is_detached_from_model(): void
+    {
+        $model = $this->makeModelWithEtsyListing();
+        $material = Material::factory()->create();
+        $model->materials()->attach($material->id);
+
+        $syncCalled = false;
+        $mock = Mockery::mock(ModelsService::class);
+        $mock->shouldReceive('syncModelToShop')
+            ->once()
+            ->withArgs(function (Model $syncedModel) use ($model, &$syncCalled): bool {
+                $syncCalled = $syncedModel->id === $model->id;
+
+                return true;
+            });
+        $this->app->bind(ModelsService::class, fn () => $mock);
+
+        $model->materials()->detach($material->id);
+
+        $this->assertTrue($syncCalled, 'syncModelToShop should have been called with the correct model');
+    }
+
+    #[Test]
+    public function it_does_not_sync_when_model_has_no_etsy_listing(): void
+    {
+        $shopOwner = ShopOwner::factory()->create();
+        $model = Model::factory()->create([
+            'customer_id' => $shopOwner->customer_id,
+        ]);
+        Shop::factory()->etsy()->create(['shop_owner_id' => $shopOwner->id]);
+        $material = Material::factory()->create();
+        $model->materials()->attach($material->id);
+
+        $mock = Mockery::mock(ModelsService::class);
+        $mock->shouldNotReceive('syncModelToShop');
+        $this->app->bind(ModelsService::class, fn () => $mock);
+
+        $model->materials()->detach($material->id);
+    }
+
+    #[Test]
+    public function it_does_not_sync_when_model_has_no_shop_owner(): void
+    {
+        $model = Model::factory()->create();
+        $material = Material::factory()->create();
+        $model->materials()->attach($material->id);
+
+        $mock = Mockery::mock(ModelsService::class);
+        $mock->shouldNotReceive('syncModelToShop');
+        $this->app->bind(ModelsService::class, fn () => $mock);
+
+        $model->materials()->detach($material->id);
+    }
+
+    #[Test]
+    public function it_does_not_sync_when_shop_is_inactive(): void
+    {
+        $shopOwner = ShopOwner::factory()->create();
+        $model = Model::factory()->create([
+            'customer_id' => $shopOwner->customer_id,
+        ]);
+        $shop = Shop::factory()->etsy()->inactive()->create(['shop_owner_id' => $shopOwner->id]);
+        ShopListingModel::create([
+            'shop_owner_id' => $shopOwner->id,
+            'shop_id' => $shop->id,
+            'model_id' => $model->id,
+            'shop_listing_id' => 999,
+        ]);
+        $material = Material::factory()->create();
+        $model->materials()->attach($material->id);
+
+        $mock = Mockery::mock(ModelsService::class);
+        $mock->shouldNotReceive('syncModelToShop');
+        $this->app->bind(ModelsService::class, fn () => $mock);
+
+        $model->materials()->detach($material->id);
+    }
+
+    #[Test]
+    public function it_syncs_all_listings_when_material_is_detached_via_sync(): void
+    {
+        $model = $this->makeModelWithEtsyListing();
+        $materialA = Material::factory()->create();
+        $materialB = Material::factory()->create();
+        $model->materials()->attach([$materialA->id, $materialB->id]);
+
+        $syncCount = 0;
+        $mock = Mockery::mock(ModelsService::class);
+        $mock->shouldReceive('syncModelToShop')
+            ->once()
+            ->andReturnUsing(function () use (&$syncCount): void {
+                $syncCount++;
+            });
+        $this->app->bind(ModelsService::class, fn () => $mock);
+
+        // sync() with only materialB detaches materialA
+        $model->materials()->sync([$materialB->id]);
+
+        $this->assertEquals(1, $syncCount);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private function makeModelWithEtsyListing(): Model
+    {
+        $shopOwner = ShopOwner::factory()->create();
+        $model = Model::factory()->create([
+            'customer_id' => $shopOwner->customer_id,
+        ]);
+        $shop = Shop::factory()->etsy()->create(['shop_owner_id' => $shopOwner->id]);
+        ShopListingModel::create([
+            'shop_owner_id' => $shopOwner->id,
+            'shop_id' => $shop->id,
+            'model_id' => $model->id,
+            'shop_listing_id' => fake()->numberBetween(10000, 99999),
+        ]);
+
+        return $model;
+    }
+}

--- a/tests/Feature/Services/Etsy/EtsyServiceTest.php
+++ b/tests/Feature/Services/Etsy/EtsyServiceTest.php
@@ -1,0 +1,273 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Services\Etsy;
+
+use App\DTO\Shops\Etsy\ListingDTO;
+use App\DTO\Shops\Etsy\ListingInventoryDTO;
+use App\Enums\Admin\CurrencyEnum;
+use App\Models\Shop;
+use App\Services\Etsy\EtsyInventoryService;
+use App\Services\Etsy\EtsyService;
+use Mockery;
+use PHPUnit\Framework\Attributes\Test;
+use Spatie\LaravelData\DataCollection;
+use Tests\TestCase;
+
+class EtsyServiceTest extends TestCase
+{
+    private EtsyService $etsyService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->etsyService = new EtsyService;
+    }
+
+    #[Test]
+    public function it_disables_material_removed_from_model_during_inventory_update(): void
+    {
+        // Arrange: listing has Steel + Aluminium in Etsy, but model only has Steel now
+        $shop = $this->makeShop();
+
+        $listingDTO = $this->makeListingDTO($shop, [
+            ['name' => 'Steel', 'sku' => 'CAST-STL-001', 'price' => 10.00],
+        ]);
+
+        $existingInventory = [
+            'products' => [
+                $this->makeEtsyProduct('Steel', 'CAST-STL-001', 10.00, true),
+                $this->makeEtsyProduct('Aluminium', 'CAST-ALU-002', 12.00, true),
+            ],
+        ];
+
+        $capturedProducts = [];
+        $this->mockInventoryService($shop, $capturedProducts);
+
+        // Act
+        $this->etsyService->updateListingInventory($shop, $listingDTO, $existingInventory);
+
+        // Assert: Steel is kept, Aluminium is disabled
+        $this->assertCount(2, $capturedProducts);
+
+        $steel = collect($capturedProducts)->firstWhere('material', 'Steel');
+        $aluminium = collect($capturedProducts)->firstWhere('material', 'Aluminium');
+
+        $this->assertNotNull($steel, 'Steel should still be in variations');
+        $this->assertTrue($steel['is_enabled'], 'Steel should remain enabled');
+
+        $this->assertNotNull($aluminium, 'Aluminium should still be sent to Etsy (to disable it)');
+        $this->assertFalse($aluminium['is_enabled'], 'Aluminium should be disabled because it was removed from the model');
+    }
+
+    #[Test]
+    public function it_keeps_existing_sku_price_and_quantity_from_etsy_for_active_materials(): void
+    {
+        $shop = $this->makeShop();
+
+        $listingDTO = $this->makeListingDTO($shop, [
+            ['name' => 'Steel', 'sku' => 'CAST-STL-NEW', 'price' => 5.00],
+        ]);
+
+        $existingInventory = [
+            'products' => [
+                $this->makeEtsyProduct('Steel', 'CAST-STL-OLD', 99.00, true, 50),
+            ],
+        ];
+
+        $capturedProducts = [];
+        $this->mockInventoryService($shop, $capturedProducts);
+
+        $this->etsyService->updateListingInventory($shop, $listingDTO, $existingInventory);
+
+        $steel = collect($capturedProducts)->firstWhere('material', 'Steel');
+
+        $this->assertEquals('CAST-STL-OLD', $steel['sku'], 'SKU should be preserved from Etsy');
+        $this->assertEquals(99.00, $steel['price'], 'Price should be preserved from Etsy');
+        $this->assertEquals(50, $steel['quantity'], 'Quantity should be preserved from Etsy');
+    }
+
+    #[Test]
+    public function it_adds_new_material_not_yet_in_etsy(): void
+    {
+        $shop = $this->makeShop();
+
+        $listingDTO = $this->makeListingDTO($shop, [
+            ['name' => 'Steel', 'sku' => 'CAST-STL-001', 'price' => 10.00],
+            ['name' => 'Bronze', 'sku' => 'CAST-BRZ-003', 'price' => 15.00],
+        ]);
+
+        $existingInventory = [
+            'products' => [
+                $this->makeEtsyProduct('Steel', 'CAST-STL-001', 10.00, true),
+            ],
+        ];
+
+        $capturedProducts = [];
+        $this->mockInventoryService($shop, $capturedProducts);
+
+        $this->etsyService->updateListingInventory($shop, $listingDTO, $existingInventory);
+
+        $materials = array_column($capturedProducts, 'material');
+
+        $this->assertContains('Steel', $materials);
+        $this->assertContains('Bronze', $materials);
+        $this->assertCount(2, $capturedProducts);
+    }
+
+    #[Test]
+    public function it_disables_multiple_removed_materials(): void
+    {
+        $shop = $this->makeShop();
+
+        // Only Bronze remains active
+        $listingDTO = $this->makeListingDTO($shop, [
+            ['name' => 'Bronze', 'sku' => 'CAST-BRZ-003', 'price' => 15.00],
+        ]);
+
+        $existingInventory = [
+            'products' => [
+                $this->makeEtsyProduct('Steel', 'CAST-STL-001', 10.00, true),
+                $this->makeEtsyProduct('Aluminium', 'CAST-ALU-002', 12.00, true),
+                $this->makeEtsyProduct('Bronze', 'CAST-BRZ-003', 15.00, true),
+            ],
+        ];
+
+        $capturedProducts = [];
+        $this->mockInventoryService($shop, $capturedProducts);
+
+        $this->etsyService->updateListingInventory($shop, $listingDTO, $existingInventory);
+
+        $this->assertCount(3, $capturedProducts);
+
+        $steel = collect($capturedProducts)->firstWhere('material', 'Steel');
+        $aluminium = collect($capturedProducts)->firstWhere('material', 'Aluminium');
+        $bronze = collect($capturedProducts)->firstWhere('material', 'Bronze');
+
+        $this->assertFalse($steel['is_enabled'], 'Steel should be disabled');
+        $this->assertFalse($aluminium['is_enabled'], 'Aluminium should be disabled');
+        $this->assertTrue($bronze['is_enabled'], 'Bronze (enabled in Etsy) should remain enabled');
+    }
+
+    #[Test]
+    public function it_handles_empty_existing_inventory(): void
+    {
+        $shop = $this->makeShop();
+
+        $listingDTO = $this->makeListingDTO($shop, [
+            ['name' => 'Steel', 'sku' => 'CAST-STL-001', 'price' => 10.00],
+        ]);
+
+        $capturedProducts = [];
+        $this->mockInventoryService($shop, $capturedProducts);
+
+        $this->etsyService->updateListingInventory($shop, $listingDTO, []);
+
+        $this->assertCount(1, $capturedProducts);
+        $this->assertEquals('Steel', $capturedProducts[0]['material']);
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private function makeShop(): Shop
+    {
+        $shop = new Shop;
+        $shop->id = 1;
+        $shop->setRawAttributes([
+            'shop_oauth' => json_encode([
+                'access_token' => 'test-token',
+                'client_id' => 'test-client',
+                'shop_id' => 12345,
+                'shop_currency' => 'USD',
+            ]),
+        ]);
+
+        return $shop;
+    }
+
+    private function makeListingDTO(Shop $shop, array $materials): ListingDTO
+    {
+        $inventoryItems = collect($materials)->map(fn (array $m) => new ListingInventoryDTO(
+            listingId: 999,
+            sku: $m['sku'],
+            name: $m['name'],
+            price: $m['price'],
+            quantity: 999,
+            currency: CurrencyEnum::USD,
+            isEnabled: false,
+        ));
+
+        return new ListingDTO(
+            shopId: 12345,
+            listingId: 999,
+            state: 'active',
+            quantity: 999,
+            title: 'Test Listing',
+            description: 'Test',
+            price: $materials[0]['price'],
+            whoMade: 'i_did',
+            whenMade: 'made_to_order',
+            taxonomyId: 1,
+            shippingProfileId: 1,
+            returnPolicyId: 1,
+            materials: collect(array_column($materials, 'name')),
+            itemWeight: 1.0,
+            itemLength: 1.0,
+            itemWidth: 1.0,
+            itemHeight: 1.0,
+            itemWeightUnit: 'g',
+            itemDimensionsUnit: 'cm',
+            processingMin: 1,
+            processingMax: 10,
+            listingImages: null,
+            listingInventory: new DataCollection(
+                ListingInventoryDTO::class,
+                $inventoryItems->all()
+            ),
+        );
+    }
+
+    private function makeEtsyProduct(string $material, string $sku, float $price, bool $isEnabled, int $quantity = 999): array
+    {
+        return [
+            'sku' => $sku,
+            'property_values' => [
+                [
+                    'property_id' => 514,
+                    'property_name' => 'Material',
+                    'values' => [$material],
+                ],
+            ],
+            'offerings' => [
+                [
+                    'price' => [
+                        'amount' => (int) ($price * 100),
+                        'divisor' => 100,
+                        'currency_code' => 'USD',
+                    ],
+                    'quantity' => $quantity,
+                    'is_enabled' => $isEnabled,
+                ],
+            ],
+        ];
+    }
+
+    private function mockInventoryService(Shop $shop, array &$capturedProducts): void
+    {
+        $mock = Mockery::mock(EtsyInventoryService::class);
+        $mock->shouldReceive('updateInventory')
+            ->once()
+            ->withArgs(function (int $listingId, array $products, mixed $readinessStateId) use (&$capturedProducts): bool {
+                $capturedProducts = $products;
+
+                return true;
+            })
+            ->andReturn(null);
+
+        $this->app->bind(EtsyInventoryService::class, fn () => $mock);
+    }
+}


### PR DESCRIPTION
When a material is unlinked from a model, the next listing sync would re-add it to Etsy inventory unchanged (from the existing Etsy products loop). Now, materials present in Etsy but absent from the model's active inventory are sent with is_enabled=false, hiding them from the listing.

Also resolves EtsyInventoryService via app() to allow test mocking.