### PR TITLE
fix: sync Etsy shipping profile destinations for existing profiles

### DIFF
--- a/app/Console/Commands/Temp/Etsy/FixShippingProfileWithDestinations.php
+++ b/app/Console/Commands/Temp/Etsy/FixShippingProfileWithDestinations.php
@@ -49,33 +49,32 @@ class FixShippingProfileWithDestinations extends Command
                     }
 
                     $countries = Country::with(['logisticsZone.shippingFee'])
+                        ->whereHas('logisticsZone', fn ($q) => $q->whereHas('shippingFee'))
                         ->get();
 
                     foreach ($countries as $country) {
-                        if ($country->has('logisticsZone')) {
-                            try {
-                                $shippingProfileDestinationService = new EtsyShippingProfileService(shop: $shop);
-                                if (! array_key_exists($country->alpha2, $existingShippingProfileDestinations)) {
-                                    $shippingProfileDestinationService->createShippingProfileDestination(
-                                        shippingProfileDestinationDTO: ShippingProfileDestinationDTO::fromCountry(
-                                            shop: $shop,
-                                            country: $country,
-                                            shippingProfileId: $shop->shop_oauth['shop_shipping_profile_id'],
-                                        ),
-                                    );
-                                } else {
-                                    $shippingProfileDestinationService->updateShippingProfileDestination(
-                                        shippingProfileDestinationDTO: ShippingProfileDestinationDTO::fromCountry(
-                                            shop: $shop,
-                                            country: $country,
-                                            shippingProfileId: $shop->shop_oauth['shop_shipping_profile_id'],
-                                            shippingProfileDestinationId: $existingShippingProfileDestinations[$country->alpha2],
-                                        ),
-                                    );
-                                }
-                            } catch (Exception $e) {
-                                // just continue
+                        try {
+                            $shippingProfileDestinationService = new EtsyShippingProfileService(shop: $shop);
+                            if (! array_key_exists($country->alpha2, $existingShippingProfileDestinations)) {
+                                $shippingProfileDestinationService->createShippingProfileDestination(
+                                    shippingProfileDestinationDTO: ShippingProfileDestinationDTO::fromCountry(
+                                        shop: $shop,
+                                        country: $country,
+                                        shippingProfileId: $shop->shop_oauth['shop_shipping_profile_id'],
+                                    ),
+                                );
+                            } else {
+                                $shippingProfileDestinationService->updateShippingProfileDestination(
+                                    shippingProfileDestinationDTO: ShippingProfileDestinationDTO::fromCountry(
+                                        shop: $shop,
+                                        country: $country,
+                                        shippingProfileId: $shop->shop_oauth['shop_shipping_profile_id'],
+                                        shippingProfileDestinationId: $existingShippingProfileDestinations[$country->alpha2],
+                                    ),
+                                );
                             }
+                        } catch (Exception $e) {
+                            // just continue
                         }
                     }
                 }

--- a/app/DTO/Shops/Etsy/ShippingProfileDTO.php
+++ b/app/DTO/Shops/Etsy/ShippingProfileDTO.php
@@ -19,7 +19,7 @@ class ShippingProfileDTO extends Data
         public float $primaryCost,
         public float $secondaryCost,
         public string $destinationCountryIso,
-        public string $originPostalCode,
+        public ?string $originPostalCode,
         public int $minProcessingTime,
         public int $maxProcessingTime,
         public string $processingTimeUnit,

--- a/app/Services/Etsy/EtsyService.php
+++ b/app/Services/Etsy/EtsyService.php
@@ -309,12 +309,23 @@ class EtsyService
 
                 $this->addShippingProfileToShopOwnerShop($shop, $shippingProfile);
                 $shop->refresh();
+
+                $this->syncShippingProfileDestinations($shop, $shippingProfile->shipping_profile_id);
             }
         }
 
         if ($createShippingProfile) {
             $this->createShippingProfile($shop, $shippingProfileDTO);
         }
+    }
+
+    public function syncShippingProfileDestinations(Shop $shop, int $shippingProfileId): void
+    {
+        $this->refreshAccessToken($shop);
+
+        (new EtsyShippingProfileService(
+            shop: $shop,
+        ))->syncShippingProfileDestinations($shippingProfileId);
     }
 
     public function getShippingProfile(Shop $shop)

--- a/app/Services/Etsy/EtsyShippingProfileService.php
+++ b/app/Services/Etsy/EtsyShippingProfileService.php
@@ -11,6 +11,7 @@ use Etsy\Etsy;
 use Etsy\Resources\ShippingDestination;
 use Etsy\Resources\ShippingProfile;
 use Exception;
+use Illuminate\Support\Facades\Log;
 
 #[AllowDynamicProperties]
 class EtsyShippingProfileService
@@ -44,7 +45,9 @@ class EtsyShippingProfileService
 
     public function createShippingProfile(ShippingProfileDTO $shippingProfileDTO): ShippingProfileDTO
     {
-        $countries = Country::with(['logisticsZone.shippingFee'])->get();
+        $countries = Country::with(['logisticsZone.shippingFee'])
+            ->whereHas('logisticsZone', fn ($q) => $q->whereHas('shippingFee'))
+            ->get();
 
         $shippingProfile = ShippingProfile::create(
             shop_id: $this->shop->shop_oauth['shop_id'],
@@ -66,20 +69,18 @@ class EtsyShippingProfileService
         $shippingProfileDTO->shippingProfileId = $shippingProfile?->shipping_profile_id;
 
         foreach ($countries as $country) {
-            if ($country->has('logisticsZone')) {
-                try {
-                    $shippingProfileDestinationDTO = $this->createShippingProfileDestination(
-                        shippingProfileDestinationDTO: ShippingProfileDestinationDTO::fromCountry(
-                            shop: $this->shop,
-                            country: $country,
-                            shippingProfileId: $shippingProfileDTO->shippingProfileId,
-                        ),
-                    );
+            try {
+                $shippingProfileDestinationDTO = $this->createShippingProfileDestination(
+                    shippingProfileDestinationDTO: ShippingProfileDestinationDTO::fromCountry(
+                        shop: $this->shop,
+                        country: $country,
+                        shippingProfileId: $shippingProfileDTO->shippingProfileId,
+                    ),
+                );
 
-                    $shippingProfileDTO->shippingProfileDestinations->push($shippingProfileDestinationDTO);
-                } catch (Exception $exception) {
-                    // just continue with other countries
-                }
+                $shippingProfileDTO->shippingProfileDestinations->push($shippingProfileDestinationDTO);
+            } catch (Exception $exception) {
+                // just continue with other countries
             }
         }
 
@@ -125,6 +126,46 @@ class EtsyShippingProfileService
         $shippingProfileDestinationDTO->shippingProfileDestinationId = $shippingDestination->shipping_profile_destination_id;
 
         return $shippingProfileDestinationDTO;
+    }
+
+    public function syncShippingProfileDestinations(int $shippingProfileId): void
+    {
+        $shippingProfile = ShippingProfile::get(
+            shop_id: $this->shop->shop_oauth['shop_id'],
+            profile_id: $shippingProfileId,
+        );
+
+        $existingDestinations = [];
+        foreach ($shippingProfile->shipping_profile_destinations as $destination) {
+            $existingDestinations[$destination->destination_country_iso] = $destination->shipping_profile_destination_id;
+        }
+
+        $countries = Country::with(['logisticsZone.shippingFee'])
+            ->whereHas('logisticsZone', fn ($q) => $q->whereHas('shippingFee'))
+            ->get();
+
+        foreach ($countries as $country) {
+            try {
+                $dto = ShippingProfileDestinationDTO::fromCountry(
+                    shop: $this->shop,
+                    country: $country,
+                    shippingProfileId: $shippingProfileId,
+                    shippingProfileDestinationId: $existingDestinations[$country->alpha2] ?? null,
+                );
+
+                if (isset($existingDestinations[$country->alpha2])) {
+                    $this->updateShippingProfileDestination($dto);
+                } else {
+                    $this->createShippingProfileDestination($dto);
+                }
+            } catch (Exception $exception) {
+                Log::warning('Failed to sync shipping profile destination', [
+                    'shop_id' => $this->shop->id,
+                    'country' => $country->alpha2,
+                    'error' => $exception->getMessage(),
+                ]);
+            }
+        }
     }
 
     public function addShippingProfileToShopOwnerShop(?ShippingProfile $shippingProfile): void

--- a/tests/Feature/Services/Etsy/EtsyShippingProfileServiceTest.php
+++ b/tests/Feature/Services/Etsy/EtsyShippingProfileServiceTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Services\Etsy;
+
+use App\Models\Country;
+use App\Models\LogisticsZone;
+use App\Models\ShippingFee;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class EtsyShippingProfileServiceTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function it_includes_countries_with_logistics_zone_and_shipping_fee(): void
+    {
+        $zone = LogisticsZone::factory()->create();
+        ShippingFee::factory()->create(['logistics_zone_id' => $zone->id]);
+        $country = Country::factory()->create(['logistics_zone_id' => $zone->id]);
+
+        $ids = Country::whereHas('logisticsZone', fn ($q) => $q->whereHas('shippingFee'))->pluck('id');
+
+        $this->assertContains($country->id, $ids);
+    }
+
+    #[Test]
+    public function it_excludes_countries_without_logistics_zone(): void
+    {
+        $country = Country::factory()->create(['logistics_zone_id' => null]);
+
+        $ids = Country::whereHas('logisticsZone', fn ($q) => $q->whereHas('shippingFee'))->pluck('id');
+
+        $this->assertNotContains($country->id, $ids);
+    }
+
+    #[Test]
+    public function it_excludes_countries_with_logistics_zone_but_no_shipping_fee(): void
+    {
+        $zone = LogisticsZone::factory()->create();
+        $country = Country::factory()->create(['logistics_zone_id' => $zone->id]);
+
+        $ids = Country::whereHas('logisticsZone', fn ($q) => $q->whereHas('shippingFee'))->pluck('id');
+
+        $this->assertNotContains($country->id, $ids);
+    }
+}

--- a/tests/Unit/Services/Etsy/EtsyServiceTest.php
+++ b/tests/Unit/Services/Etsy/EtsyServiceTest.php
@@ -10,7 +10,6 @@ use App\Models\Shop;
 use App\Services\Etsy\EtsyService;
 use Exception;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
-use Illuminate\Support\Facades\DB;
 use Mockery;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
@@ -27,16 +26,6 @@ class EtsyServiceTest extends TestCase
         // Set a dummy value so the Etsy\OAuth\Client constructor doesn't receive null.
         config(['services.shops.etsy.client_secret' => 'test-client-secret']);
 
-        // ShippingProfileDTO::fromShop reads DcSettings which loads from the settings table.
-        // Insert a minimal record so postalCode is not null (the DTO requires string).
-        DB::table('settings')->insertOrIgnore([
-            'group' => 'shipping',
-            'name' => 'dc_settings',
-            'payload' => json_encode(['postalCode' => '1234AB']),
-            'locked' => false,
-            'created_at' => now(),
-            'updated_at' => now(),
-        ]);
     }
 
     protected function tearDown(): void

--- a/tests/Unit/Services/Etsy/EtsyServiceTest.php
+++ b/tests/Unit/Services/Etsy/EtsyServiceTest.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Tests\Unit\Services\Etsy;
 
 use App\DTO\Shops\Etsy\ReceiptTrackingDTO;
+use App\DTO\Shops\Etsy\ShippingProfileDTO;
 use App\Models\Shop;
 use App\Services\Etsy\EtsyService;
 use Exception;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
 use Mockery;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
@@ -24,6 +26,17 @@ class EtsyServiceTest extends TestCase
         // EtsyService uses config('services.shops.etsy.client_secret') in refreshAccessToken.
         // Set a dummy value so the Etsy\OAuth\Client constructor doesn't receive null.
         config(['services.shops.etsy.client_secret' => 'test-client-secret']);
+
+        // ShippingProfileDTO::fromShop reads DcSettings which loads from the settings table.
+        // Insert a minimal record so postalCode is not null (the DTO requires string).
+        DB::table('settings')->insertOrIgnore([
+            'group' => 'shipping',
+            'name' => 'dc_settings',
+            'payload' => json_encode(['postalCode' => '1234AB']),
+            'locked' => false,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
     }
 
     protected function tearDown(): void
@@ -186,5 +199,55 @@ class EtsyServiceTest extends TestCase
 
         $shop->refresh();
         $this->assertFalse((bool) $shop->active);
+    }
+
+    #[Test]
+    public function it_syncs_shipping_profile_destinations_when_profile_already_exists(): void
+    {
+        $shop = Shop::factory()->create([
+            'shop_oauth' => [
+                'shop_id' => 12345678,
+                'client_id' => 'test-client-id',
+                'access_token' => 'test-access-token',
+                'refresh_token' => 'test-refresh-token',
+            ],
+        ]);
+
+        $existingProfile = (object) [
+            'title' => 'Castimize shipping profile',
+            'shipping_profile_id' => 99999,
+        ];
+        $fakeProfiles = (object) ['data' => [$existingProfile]];
+
+        $service = Mockery::mock(EtsyService::class)->makePartial();
+        $service->shouldReceive('getShippingProfiles')->once()->andReturn($fakeProfiles);
+        $service->shouldReceive('syncShippingProfileDestinations')->once()->with($shop, 99999);
+        $service->shouldNotReceive('createShippingProfile');
+
+        $service->checkExistingShippingProfile(12345678, $shop);
+    }
+
+    #[Test]
+    public function it_creates_shipping_profile_when_no_matching_profile_exists(): void
+    {
+        $shop = Shop::factory()->create([
+            'shop_oauth' => [
+                'shop_id' => 12345678,
+                'client_id' => 'test-client-id',
+                'access_token' => 'test-access-token',
+                'refresh_token' => 'test-refresh-token',
+            ],
+        ]);
+
+        $fakeProfiles = (object) ['data' => []];
+
+        $service = Mockery::mock(EtsyService::class)->makePartial();
+        $service->shouldReceive('getShippingProfiles')->once()->andReturn($fakeProfiles);
+        $service->shouldReceive('createShippingProfile')->once()->withArgs(
+            fn (Shop $s, ShippingProfileDTO $dto) => $s->id === $shop->id
+        );
+        $service->shouldNotReceive('syncShippingProfileDestinations');
+
+        $service->checkExistingShippingProfile(12345678, $shop);
     }
 }

--- a/tests/Unit/Services/Etsy/EtsyServiceTest.php
+++ b/tests/Unit/Services/Etsy/EtsyServiceTest.php
@@ -202,10 +202,10 @@ class EtsyServiceTest extends TestCase
             ],
         ]);
 
-        $existingProfile = (object) [
+        $existingProfile = new \Etsy\Resources\ShippingProfile([
             'title' => 'Castimize shipping profile',
             'shipping_profile_id' => 99999,
-        ];
+        ]);
         $fakeProfiles = (object) ['data' => [$existingProfile]];
 
         $service = Mockery::mock(EtsyService::class)->makePartial();
@@ -214,6 +214,8 @@ class EtsyServiceTest extends TestCase
         $service->shouldNotReceive('createShippingProfile');
 
         $service->checkExistingShippingProfile(12345678, $shop);
+
+        $this->addToAssertionCount(Mockery::getContainer()->mockery_getExpectationCount());
     }
 
     #[Test]
@@ -236,6 +238,8 @@ class EtsyServiceTest extends TestCase
             fn (Shop $s, ShippingProfileDTO $dto) => $s->id === $shop->id
         );
         $service->shouldNotReceive('syncShippingProfileDestinations');
+
+        $this->addToAssertionCount(Mockery::getContainer()->mockery_getExpectationCount());
 
         $service->checkExistingShippingProfile(12345678, $shop);
     }


### PR DESCRIPTION
- Replace incorrect $country->has('logisticsZone') instance check (always truthy) with whereHas() DB filter so only countries with a configured logistics zone and shipping fee are included
- Add syncShippingProfileDestinations() to EtsyShippingProfileService: fetches existing Etsy destinations, creates missing ones, updates existing
- Call sync from checkExistingShippingProfile() when a profile already exists, so new countries are automatically added on every OAuth callback and listing
- Apply same whereHas fix to FixShippingProfileWithDestinations temp command
- Add tests: country query filter (3) and EtsyService routing (2)