### PR TITLE
fix: add detailed logging to getShopListingsFromReceipt for missing l…

### DIFF
--- a/app/Console/Commands/GetEtsyReceipts.php
+++ b/app/Console/Commands/GetEtsyReceipts.php
@@ -145,6 +145,10 @@ class GetEtsyReceipts extends Command
                                 $this->error("Failed to process receipt {$receipt->receipt_id}: ".$e->getMessage());
                             }
                         } else {
+                            Log::channel('etsy')->warning('GetEtsyReceipts: receipt has no matching listings, skipping', [
+                                'shop_id' => $shop->id,
+                                'receipt_id' => $receipt->receipt_id,
+                            ]);
                             $this->warn("Receipt {$receipt->receipt_id} has no matching listings, skipping");
                         }
                     } else {

--- a/app/Services/Etsy/EtsyService.php
+++ b/app/Services/Etsy/EtsyService.php
@@ -850,17 +850,58 @@ class EtsyService
                 ->where('shop_listing_id', $transaction->listing_id)
                 ->where('created_at', '<=', Carbon::createFromTimestamp($receipt->created_timestamp))
                 ->first();
-            if ($shopListingModel) {
-                foreach ($transaction->variations as $variation) {
-                    $material = $shopListingModel->model->materials->where('name', $variation->formatted_value)->first();
-                    if ($variation->formatted_name === 'Material' && $material) {
-                        $lines[] = [
-                            'transaction' => $transaction,
-                            'shop_listing_model' => $shopListingModel,
-                            'material' => $material,
-                        ];
-                    }
+
+            if (! $shopListingModel) {
+                Log::channel('etsy')->warning('getShopListingsFromReceipt: no ShopListingModel found for transaction', [
+                    'shop_id' => $shop->id,
+                    'receipt_id' => $receipt->receipt_id,
+                    'listing_id' => $transaction->listing_id,
+                    'transaction_id' => $transaction->transaction_id,
+                    'receipt_created_timestamp' => $receipt->created_timestamp,
+                ]);
+
+                continue;
+            }
+
+            $matchedLine = false;
+            foreach ($transaction->variations as $variation) {
+                if ($variation->formatted_name !== 'Material') {
+                    continue;
                 }
+
+                $material = $shopListingModel->model->materials->where('name', $variation->formatted_value)->first();
+                if (! $material) {
+                    Log::channel('etsy')->warning('getShopListingsFromReceipt: material not found for variation', [
+                        'shop_id' => $shop->id,
+                        'receipt_id' => $receipt->receipt_id,
+                        'listing_id' => $transaction->listing_id,
+                        'transaction_id' => $transaction->transaction_id,
+                        'variation_value' => $variation->formatted_value,
+                        'available_materials' => $shopListingModel->model->materials->pluck('name'),
+                    ]);
+
+                    continue;
+                }
+
+                $lines[] = [
+                    'transaction' => $transaction,
+                    'shop_listing_model' => $shopListingModel,
+                    'material' => $material,
+                ];
+                $matchedLine = true;
+            }
+
+            if (! $matchedLine) {
+                Log::channel('etsy')->warning('getShopListingsFromReceipt: no matching Material variation found for transaction', [
+                    'shop_id' => $shop->id,
+                    'receipt_id' => $receipt->receipt_id,
+                    'listing_id' => $transaction->listing_id,
+                    'transaction_id' => $transaction->transaction_id,
+                    'variations' => collect($transaction->variations)->map(fn ($v) => [
+                        'name' => $v->formatted_name,
+                        'value' => $v->formatted_value,
+                    ])->all(),
+                ]);
             }
         }
 


### PR DESCRIPTION
…istings

Log the exact reason why a receipt has no matching lines:
- ShopListingModel not found (includes listing_id, shop_id, timestamp)
- Material variation not found (includes variation value + available materials)
- No Material variation on the transaction at all (includes all variations)

Also log a warning from the command when skipping a receipt with no lines.