### PR TITLE
fix: allow ShopListingModel created up to 1 day after receipt timestamp

### DIFF
--- a/app/Services/Etsy/EtsyService.php
+++ b/app/Services/Etsy/EtsyService.php
@@ -858,7 +858,7 @@ class EtsyService
             $shopListingModel = ShopListingModel::with('model.materials')
                 ->where('shop_id', $shop->id)
                 ->where('shop_listing_id', $transaction->listing_id)
-                ->where('created_at', '<=', Carbon::createFromTimestamp($receipt->created_timestamp))
+                ->where('created_at', '<=', Carbon::createFromTimestamp($receipt->created_timestamp)->addDay())
                 ->first();
 
             if (! $shopListingModel) {


### PR DESCRIPTION
Listings synced slightly after a receipt was placed were excluded by the strict created_at <= receipt_timestamp constraint. Adding a 1-day window handles cases where the local sync lags behind the Etsy order.