### PR TITLE
fix: propagate exceptions in SyncInvoicePaidToExact so job retries on…

### DIFF
--- a/app/Console/Commands/SyncMissingDiary90ToExact.php
+++ b/app/Console/Commands/SyncMissingDiary90ToExact.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Jobs\SyncInvoicePaidToExact;
+use App\Models\Invoice;
+use Illuminate\Console\Command;
+
+class SyncMissingDiary90ToExact extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'castimize:sync-missing-diary-90-to-exact';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Dispatch SyncInvoicePaidToExact for invoices that have a diary 70 entry but are missing diary 90';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): void
+    {
+        $invoices = Invoice::with('customer')
+            ->whereHas('exactSalesEntries', function ($query) {
+                $query->where('diary', 70);
+            })
+            ->whereDoesntHave('exactSalesEntries', function ($query) {
+                $query->where('diary', 90);
+            })
+            ->orderBy('invoice_number')
+            ->get();
+
+        $count = $invoices->count();
+        $progressBar = $this->output->createProgressBar($count);
+        $this->info("Dispatching diary 90 sync for {$count} invoices");
+        $progressBar->start();
+
+        foreach ($invoices as $invoice) {
+            SyncInvoicePaidToExact::dispatch($invoice, $invoice->customer->wp_id)
+                ->onQueue('exact');
+
+            $progressBar->advance();
+        }
+
+        $progressBar->finish();
+        $this->newLine();
+        $this->info('Done.');
+    }
+}

--- a/app/Jobs/SyncInvoicePaidToExact.php
+++ b/app/Jobs/SyncInvoicePaidToExact.php
@@ -41,15 +41,11 @@ class SyncInvoicePaidToExact implements ShouldQueue
             return;
         }
 
-        try {
-            if ($customer->exact_online_guid === null) {
-                throw new Exception('Customer exact_online_guid is null');
-            }
-
-            $exactOnlineService->syncInvoicePaid($this->invoice);
-        } catch (Throwable $e) {
-            Log::channel('exact')->error($e->getMessage().PHP_EOL.$e->getTraceAsString());
+        if ($customer->exact_online_guid === null) {
+            throw new Exception('Customer exact_online_guid is null');
         }
+
+        $exactOnlineService->syncInvoicePaid($this->invoice);
 
         try {
             LogRequestService::addResponseById($this->logRequestId, $this->invoice);

--- a/tests/Feature/Console/Commands/SyncMissingDiary90ToExactTest.php
+++ b/tests/Feature/Console/Commands/SyncMissingDiary90ToExactTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console\Commands;
+
+use App\Jobs\SyncInvoicePaidToExact;
+use App\Models\Customer;
+use App\Models\Invoice;
+use App\Models\InvoiceExactSalesEntry;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Queue;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SyncMissingDiary90ToExactTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private Customer $customer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+
+        $this->customer = Customer::factory()->create([
+            'wp_id' => 77777,
+        ]);
+    }
+
+    private function createInvoice(string $number): Invoice
+    {
+        return Invoice::create([
+            'customer_id' => $this->customer->id,
+            'invoice_number' => $number,
+            'invoice_date' => now(),
+            'debit' => true,
+            'total' => 100.00,
+            'total_tax' => 21.00,
+            'currency_code' => 'EUR',
+            'paid' => true,
+            'paid_at' => now(),
+        ]);
+    }
+
+    #[Test]
+    public function it_dispatches_job_for_invoices_with_diary_70_but_missing_diary_90(): void
+    {
+        $invoice = $this->createInvoice('INV-MISSING-90');
+        InvoiceExactSalesEntry::create([
+            'invoice_id' => $invoice->id,
+            'exact_online_guid' => 'guid-diary-70',
+            'diary' => 70,
+            'exact_data' => [],
+        ]);
+
+        $this->artisan('castimize:sync-missing-diary-90-to-exact')
+            ->assertSuccessful();
+
+        Queue::assertPushed(SyncInvoicePaidToExact::class, function ($job) use ($invoice) {
+            return $job->invoice->id === $invoice->id;
+        });
+    }
+
+    #[Test]
+    public function it_does_not_dispatch_job_for_invoices_with_both_diary_70_and_diary_90(): void
+    {
+        $invoice = $this->createInvoice('INV-COMPLETE');
+        InvoiceExactSalesEntry::create([
+            'invoice_id' => $invoice->id,
+            'exact_online_guid' => 'guid-complete-70',
+            'diary' => 70,
+            'exact_data' => [],
+        ]);
+        InvoiceExactSalesEntry::create([
+            'invoice_id' => $invoice->id,
+            'exact_online_guid' => 'guid-complete-90',
+            'diary' => 90,
+            'exact_data' => [],
+        ]);
+
+        $this->artisan('castimize:sync-missing-diary-90-to-exact')
+            ->assertSuccessful();
+
+        Queue::assertNotPushed(SyncInvoicePaidToExact::class);
+    }
+
+    #[Test]
+    public function it_does_not_dispatch_job_for_invoices_with_no_exact_entries_at_all(): void
+    {
+        $this->createInvoice('INV-NO-ENTRIES');
+
+        $this->artisan('castimize:sync-missing-diary-90-to-exact')
+            ->assertSuccessful();
+
+        Queue::assertNotPushed(SyncInvoicePaidToExact::class);
+    }
+
+    #[Test]
+    public function it_dispatches_jobs_for_multiple_invoices_missing_diary_90(): void
+    {
+        $invoice1 = $this->createInvoice('INV-MISSING-90-A');
+        $invoice2 = $this->createInvoice('INV-MISSING-90-B');
+
+        foreach ([$invoice1, $invoice2] as $i => $invoice) {
+            InvoiceExactSalesEntry::create([
+                'invoice_id' => $invoice->id,
+                'exact_online_guid' => "guid-70-{$i}",
+                'diary' => 70,
+                'exact_data' => [],
+            ]);
+        }
+
+        $this->artisan('castimize:sync-missing-diary-90-to-exact')
+            ->assertSuccessful();
+
+        Queue::assertPushed(SyncInvoicePaidToExact::class, 2);
+    }
+}

--- a/tests/Feature/Jobs/SyncInvoicePaidToExactTest.php
+++ b/tests/Feature/Jobs/SyncInvoicePaidToExactTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Jobs;
+
+use App\Jobs\SyncInvoicePaidToExact;
+use App\Models\Customer;
+use App\Models\Invoice;
+use App\Services\Exact\ExactOnlineService;
+use Exception;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Queue;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SyncInvoicePaidToExactTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private Customer $customer;
+
+    private Invoice $invoice;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->customer = Customer::factory()->create([
+            'wp_id' => 55555,
+            'exact_online_guid' => 'test-guid-123',
+        ]);
+
+        $this->invoice = Invoice::create([
+            'customer_id' => $this->customer->id,
+            'invoice_number' => 'INV-TEST-001',
+            'invoice_date' => now(),
+            'debit' => true,
+            'total' => 100.00,
+            'total_tax' => 21.00,
+            'currency_code' => 'EUR',
+            'paid' => true,
+            'paid_at' => now(),
+        ]);
+    }
+
+    #[Test]
+    public function it_can_be_dispatched_to_queue(): void
+    {
+        Queue::fake();
+
+        SyncInvoicePaidToExact::dispatch($this->invoice, 55555);
+
+        Queue::assertPushed(SyncInvoicePaidToExact::class, function ($job) {
+            return $job->wpCustomerId === 55555;
+        });
+    }
+
+    #[Test]
+    public function it_has_correct_retry_configuration(): void
+    {
+        $job = new SyncInvoicePaidToExact($this->invoice, 55555);
+
+        $this->assertEquals(5, $job->tries);
+        $this->assertEquals(120, $job->timeout);
+    }
+
+    #[Test]
+    public function it_skips_when_customer_not_found_in_database(): void
+    {
+        $exactOnlineService = $this->mock(ExactOnlineService::class);
+        $exactOnlineService->shouldNotReceive('syncInvoicePaid');
+
+        $job = new SyncInvoicePaidToExact($this->invoice, 99999);
+        $job->handle($exactOnlineService);
+
+        $this->assertTrue(true);
+    }
+
+    #[Test]
+    public function it_throws_exception_when_customer_has_no_exact_guid(): void
+    {
+        Customer::factory()->create([
+            'wp_id' => 66666,
+            'exact_online_guid' => null,
+        ]);
+
+        $exactOnlineService = $this->mock(ExactOnlineService::class);
+        $exactOnlineService->shouldNotReceive('syncInvoicePaid');
+
+        $job = new SyncInvoicePaidToExact($this->invoice, 66666);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Customer exact_online_guid is null');
+
+        $job->handle($exactOnlineService);
+    }
+
+    #[Test]
+    public function it_propagates_exceptions_from_sync_so_job_can_retry(): void
+    {
+        $exactOnlineService = $this->mock(ExactOnlineService::class);
+        $exactOnlineService->shouldReceive('syncInvoicePaid')
+            ->once()
+            ->andThrow(new Exception('Exact Online API error'));
+
+        $job = new SyncInvoicePaidToExact($this->invoice, 55555);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Exact Online API error');
+
+        $job->handle($exactOnlineService);
+    }
+}


### PR DESCRIPTION
… failure

Previously all exceptions from syncInvoicePaid() were silently caught and logged, causing the job to complete successfully even when diary 90 was never created. Also adds a temp command to backfill missing diary 90 entries for invoices that already have diary 70.