### PR TITLE
fix: handle Exact Online 429 rate limit in SyncInvoicePaidToExact wit…

### DIFF
--- a/app/Console/Commands/SyncMissingDiary90ToExact.php
+++ b/app/Console/Commands/SyncMissingDiary90ToExact.php
@@ -46,6 +46,8 @@ class SyncMissingDiary90ToExact extends Command
             SyncInvoicePaidToExact::dispatch($invoice, $invoice->customer->wp_id)
                 ->onQueue('exact');
 
+            sleep(8);
+
             $progressBar->advance();
         }
 

--- a/app/Jobs/SyncInvoicePaidToExact.php
+++ b/app/Jobs/SyncInvoicePaidToExact.php
@@ -10,6 +10,7 @@ use Exception;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Log;
+use Picqer\Financials\Exact\ApiException;
 use Throwable;
 
 class SyncInvoicePaidToExact implements ShouldQueue
@@ -45,7 +46,19 @@ class SyncInvoicePaidToExact implements ShouldQueue
             throw new Exception('Customer exact_online_guid is null');
         }
 
-        $exactOnlineService->syncInvoicePaid($this->invoice);
+        try {
+            $exactOnlineService->syncInvoicePaid($this->invoice);
+        } catch (ApiException $e) {
+            if (str_contains($e->getMessage(), 'Error 429')) {
+                Log::channel('exact')->warning("SyncInvoicePaidToExact: rate limited by Exact Online for invoice {$this->invoice->invoice_number}, releasing for 60s");
+                if ($this->job !== null) {
+                    $this->release(60);
+                }
+
+                return;
+            }
+            throw $e;
+        }
 
         try {
             LogRequestService::addResponseById($this->logRequestId, $this->invoice);

--- a/tests/Feature/Jobs/SyncInvoicePaidToExactTest.php
+++ b/tests/Feature/Jobs/SyncInvoicePaidToExactTest.php
@@ -12,6 +12,7 @@ use Exception;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Queue;
 use PHPUnit\Framework\Attributes\Test;
+use Picqer\Financials\Exact\ApiException;
 use Tests\TestCase;
 
 class SyncInvoicePaidToExactTest extends TestCase
@@ -97,18 +98,34 @@ class SyncInvoicePaidToExactTest extends TestCase
     }
 
     #[Test]
-    public function it_propagates_exceptions_from_sync_so_job_can_retry(): void
+    public function it_propagates_non_rate_limit_exceptions_from_sync_so_job_can_retry(): void
     {
         $exactOnlineService = $this->mock(ExactOnlineService::class);
         $exactOnlineService->shouldReceive('syncInvoicePaid')
             ->once()
-            ->andThrow(new Exception('Exact Online API error'));
+            ->andThrow(new ApiException('Error 500: Internal Server Error'));
 
         $job = new SyncInvoicePaidToExact($this->invoice, 55555);
 
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Exact Online API error');
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessage('Error 500');
 
         $job->handle($exactOnlineService);
+    }
+
+    #[Test]
+    public function it_does_not_throw_when_exact_returns_rate_limit_error(): void
+    {
+        $exactOnlineService = $this->mock(ExactOnlineService::class);
+        $exactOnlineService->shouldReceive('syncInvoicePaid')
+            ->once()
+            ->andThrow(new ApiException('Error 429: Too Many Requests'));
+
+        $job = new SyncInvoicePaidToExact($this->invoice, 55555);
+
+        // Should not throw — job catches 429 and releases back to queue
+        $job->handle($exactOnlineService);
+
+        $this->assertTrue(true);
     }
 }


### PR DESCRIPTION
…h retry delay

When Exact returns 429, release the job back to queue after 60s instead of failing. Also adds sleep(8) between dispatches in the backfill command to avoid flooding the API.